### PR TITLE
Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "enhanced-resolve": "~2.2.2",
     "is-relative-path": "~1.0.0",
     "module-definition": "~2.2.2",
-    "module-lookup-amd": "~2.0.4",
+    "module-lookup-amd": "~3.0.0",
     "object-assign": "~4.0.1",
     "resolve": "~1.1.7",
     "resolve-dependency-path": "~1.0.2",

--- a/test/test.js
+++ b/test/test.js
@@ -61,21 +61,20 @@ describe('filing-cabinet', function() {
       });
 
       it('assumes amd for es6 modules with a requirejs config', function() {
-        var stub = sinon.stub();
-        var revert = cabinet.__set__('amdLookup', stub);
+        var spy = sinon.spy(cabinet, '_getJSType');
 
-        cabinet({
+        var result = cabinet({
           partial: './bar',
           filename: 'js/es6/foo.js',
           directory: 'js/es6/',
           config: {
-            baseUrl: 'js/'
+            baseUrl: './'
           }
         });
 
-        assert.ok(stub.called);
-
-        revert();
+        assert.ok(spy.called);
+        assert.equal(result, 'js/es6/bar.js');
+        spy.restore();
       });
     });
 
@@ -119,7 +118,7 @@ describe('filing-cabinet', function() {
           directory: 'js/commonjs/'
         });
 
-        assert.equal(result.length, 0);
+        assert.equal(result, '');
       });
 
       it('adds the directory to the require resolution paths', function() {
@@ -234,7 +233,7 @@ describe('filing-cabinet', function() {
       });
 
       assert.ok(stub.called);
-      assert.equal(path, 'foo');
+      assert.equal(path, 'foo.foobar');
     });
 
     it('allows does not break default resolvers', function() {


### PR DESCRIPTION
* Bump module-lookup-amd for optional requirejs config support
* Upgraded to the new option-based format for module-lookup-amd
* AMD: resolved paths should always have an extension