### PR TITLE
Explicitly declare version of dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "debug": "~2.2.0",
     "enhanced-resolve": "~2.2.2",
     "is-relative-path": "~1.0.0",
-    "module-definition": "~2.2.2",
+    "module-definition": "~2.2.3",
     "module-lookup-amd": "~4.0.2",
     "object-assign": "~4.0.1",
     "resolve": "~1.1.7",


### PR DESCRIPTION
Wasn't getting the newer version of module-definition on an npm install in an existing project