### PR TITLE
Webpack: strip loader (if any) from the partial

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,6 +185,9 @@ function resolveWebpackPath(partial, filename, directory, webpackConfig) {
       alias: aliases
     });
 
+    // We don't care about what the loader resolves the partial to
+    // we only wnat the path of the resolved file
+    partial = stripLoader(partial);
     var resolvedPath = resolver(directory, partial);
 
     return resolvedPath;
@@ -196,4 +199,12 @@ function resolveWebpackPath(partial, filename, directory, webpackConfig) {
   }
 
   return '';
+}
+
+function stripLoader(partial) {
+  var exclamationLocation = partial.indexOf('!');
+
+  if (exclamationLocation === -1) { return partial; }
+
+  return partial.slice(exclamationLocation + 1);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -370,5 +370,11 @@ describe('filing-cabinet', function() {
     it('resolves a non-aliased path', function() {
       testResolution('resolve');
     });
+
+    describe('when the partial contains a loader', function() {
+      it('still works', function() {
+        testResolution('hgn!resolve');
+      });
+    });
   });
 });


### PR DESCRIPTION
We're not using loaders defined within the webpack config
because we don't care about the "compiled" output from the loader.

We only care about getting a partial path to map to a filepath.